### PR TITLE
feat: Preserve input text in AI Assistant dialog on API error

### DIFF
--- a/dictdialog.lua
+++ b/dictdialog.lua
@@ -9,7 +9,7 @@ local Event = require("ui/event")
 local configuration = require("configuration")
 local dict_prompts = require("prompts").assitant_prompts.dict
 
-local function showDictionaryDialog(assitant, highlightedText, message_history)
+local function showDictionaryDialog(assitant, highlightedText, parent_dialog, message_history)
     local Querier = assitant.querier
     local ui = assitant.ui
 
@@ -44,7 +44,7 @@ local function showDictionaryDialog(assitant, highlightedText, message_history)
                             UIManager:close(input_dialog)
                             if word and word ~= "" then
                                 -- Recursively call with the entered word
-                                showDictionaryDialog(assitant, word, message_history)
+                                showDictionaryDialog(assitant, word, parent_dialog, message_history)
                             end
                         end,
                     },
@@ -130,6 +130,11 @@ local function showDictionaryDialog(assitant, highlightedText, message_history)
     if err ~= nil then
         UIManager:show(InfoMessage:new{ icon = "notice-warning", text = err })
         return
+    end
+
+    -- If we have a parent dialog (AssitantDialog) and the query was successful, close it.
+    if parent_dialog and parent_dialog._close then
+        parent_dialog:_close()
     end
 
     local function createResultText(highlightedText, answer)


### PR DESCRIPTION
This change modifies the AI Assistant dialog to prevent the input field from being cleared when an API request fails. This allows users to retry their query without retyping it.

Changes made:
- In `dialogs.lua` (`AssitantDialog:show`):
  - The main input dialog is now closed only after a successful API call from the "Ask" button.
  - For "Dictionary" and custom prompt buttons, the parent dialog closing logic was adjusted to ensure it only closes if the subsequent action is likely to succeed or navigate away permanently.
- In `dictdialog.lua` (`showDictionaryDialog`):
  - Added functionality to accept and close a parent dialog upon successful API query, allowing the main AI Assistant input dialog to be closed when the dictionary lookup is successful.